### PR TITLE
chore: pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -10,10 +10,9 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6.0.2
-
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Setup Node.js
-        uses: actions/setup-node@v6.3.0
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version: 22
           cache: 'npm'
@@ -142,7 +141,7 @@ jobs:
 
       - name: Upload coverage report (optional)
         if: always()
-        uses: actions/upload-artifact@v7.0.0
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: coverage-report
           path: coverage/

--- a/.github/workflows/echidna.yml
+++ b/.github/workflows/echidna.yml
@@ -10,10 +10,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6.0.2
-
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Setup Node.js
-        uses: actions/setup-node@v6.3.0
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version: 22
           cache: 'npm'
@@ -25,7 +24,7 @@ jobs:
         run: npx hardhat compile
 
       - name: Run Echidna for EchidnaPublicLiquidityPool
-        uses: crytic/echidna-action@v2.0.2
+        uses: crytic/echidna-action@f7e374e42bf7131f7307a92f5549ed6b2fd17c9d # v2.0.2
         with:
           solc-version: 0.8.28
           files: .
@@ -33,7 +32,7 @@ jobs:
           config: contracts/echidna/config.yaml
 
       - name: Run Echidna for EchidnaLiquidityHub
-        uses: crytic/echidna-action@v2.0.2
+        uses: crytic/echidna-action@f7e374e42bf7131f7307a92f5549ed6b2fd17c9d # v2.0.2
         with:
           solc-version: 0.8.28
           files: .
@@ -41,7 +40,7 @@ jobs:
           config: contracts/echidna/config.yaml
 
       - name: Run Echidna for EchidnaLiquidityMining
-        uses: crytic/echidna-action@v2.0.2
+        uses: crytic/echidna-action@f7e374e42bf7131f7307a92f5549ed6b2fd17c9d # v2.0.2
         with:
           solc-version: 0.8.28
           files: .
@@ -49,7 +48,7 @@ jobs:
           config: contracts/echidna/config.yaml
 
       - name: Run Echidna for EchidnaLiquidityPool
-        uses: crytic/echidna-action@v2.0.2
+        uses: crytic/echidna-action@f7e374e42bf7131f7307a92f5549ed6b2fd17c9d # v2.0.2
         with:
           solc-version: 0.8.28
           files: .

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,9 +8,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Install Node.js 22
-        uses: actions/setup-node@v6.3.0
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version: 22
           cache: 'npm'
@@ -24,9 +24,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Install Node.js 22
-        uses: actions/setup-node@v6.3.0
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version: 22
           cache: 'npm'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,11 +13,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Use default .env
         run: mv .env.example .env
       - name: Install Node.js 22
-        uses: actions/setup-node@v6.3.0
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version: 22
           cache: 'npm'


### PR DESCRIPTION
## Summary
- Pin all GitHub Action references to immutable commit SHAs instead of mutable tags
- Prevents supply chain attacks via tag poisoning (e.g. Trivy-style attacks)
- Version comments preserved inline for auditability

## Test plan
- [ ] Verify CI passes with SHA-pinned actions