### PR TITLE
fix: reject zero signer address in liquidity pool

### DIFF
--- a/contracts/LiquidityPool.sol
+++ b/contracts/LiquidityPool.sol
@@ -325,6 +325,7 @@ contract LiquidityPool is ILiquidityPool, AccessControl, EIP712, ISigner {
     }
 
     function setSignerAddress(address signerAddress_) external onlyRole(DEFAULT_ADMIN_ROLE) {
+        require(signerAddress_ != address(0), ZeroAddress());
         address oldSignerAddress = signerAddress;
         signerAddress = signerAddress_;
         emit SignerAddressSet(oldSignerAddress, signerAddress_);

--- a/test/LiquidityPool.ts
+++ b/test/LiquidityPool.ts
@@ -1762,6 +1762,12 @@ describe("LiquidityPool", function () {
         .to.eq(user.address);
     });
 
+    it("Should NOT allow admin to set signer address to 0", async function () {
+      const {liquidityPool, admin} = await loadFixture(deployAll);
+      await expect(liquidityPool.connect(admin).setSignerAddress(ZERO_ADDRESS))
+        .to.be.revertedWithCustomError(liquidityPool, "ZeroAddress()");
+    });
+
     it("Should NOT allow others to set signer address", async function () {
       const {liquidityPool, user} = await loadFixture(deployAll);
       await expect(liquidityPool.connect(user).setSignerAddress(user))


### PR DESCRIPTION
noticed setSignerAddress did not match setMPCAddress and constructor, so admin could point ERC1271 checks at address zero. now it reverts same as other admin setters.