### PR TITLE
chore: notify solver-config to refresh deployment hashes on change

### DIFF
--- a/.github/workflows/notify-solver-config.yml
+++ b/.github/workflows/notify-solver-config.yml
@@ -15,6 +15,7 @@ on:
 jobs:
   trigger-refresh:
     runs-on: ubuntu-latest
+    environment: production
     steps:
       - name: Trigger solver-config hash refresh
         env:

--- a/.github/workflows/notify-solver-config.yml
+++ b/.github/workflows/notify-solver-config.yml
@@ -1,0 +1,26 @@
+name: Notify solver-config of deployments change
+
+# When the deployment manifests that solver-config hashes change on main, trigger
+# solver-config's refresh-deployment-hashes workflow so it can regenerate the hash
+# manifest and open a PR. Uses a token scoped to Actions:write only on solver-config,
+# so this repo can trigger that workflow but cannot read or write its contents.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'deployments/deployments.yml'
+      - 'deployments/deployments.staging.yml'
+
+jobs:
+  trigger-refresh:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger solver-config hash refresh
+        env:
+          GH_TOKEN: ${{ secrets.SOLVER_CONFIG_DISPATCH_TOKEN }}
+        run: |
+          gh workflow run refresh-deployment-hashes.yml \
+            --repo sprintertech/solver-config \
+            --ref main \
+            -f source_sha="${{ github.sha }}"


### PR DESCRIPTION
## Why

`solver-config`'s `deployments-hashes.json` is `SHA256(local solvers config + remote deployments manifest)`, where the remote half is fetched from this repo's `deployments/deployments.yml` and `deployments/deployments.staging.yml`. Today, when those files change here, solver-config's committed hash silently goes stale until a human regenerates it — and its downstream consumers (gist + DigitalOcean Space) keep serving the stale hash with no notification.

## What

Adds `.github/workflows/notify-solver-config.yml`: on a push to `main` that touches `deployments/deployments.yml` or `deployments/deployments.staging.yml`, it triggers solver-config's `refresh-deployment-hashes` workflow via the official `gh` CLI. That workflow (in solver-config) regenerates the manifest and, if it changed, opens a PR there and pings Slack.

This repo only **triggers** the workflow — it never reads or writes solver-config contents. The `GH_TOKEN` is a fine-grained PAT scoped to **Actions: write only** on solver-config.

Trigger paths are scoped to exactly the two manifests solver-config hashes, so the other files in `deployments/` (deploy logs, etc.) don't cause spurious dispatches.

## Prerequisites before this is effective

- [x] Create a `production` GitHub Environment in this repo and add secret `SOLVER_CONFIG_DISPATCH_TOKEN` to it (fine-grained PAT, Actions: write only on solver-config). The trigger job runs in that environment, so you can also gate dispatches behind environment protection rules (e.g. required reviewers).
- [ ] solver-config PR sprintertech/solver-config#302 merged, so `refresh-deployment-hashes.yml` exists on solver-config's default branch (required for `workflow_dispatch` to be triggerable).

Companion issue: sprintertech/solver-config#303